### PR TITLE
modify: remove 'show' and add events

### DIFF
--- a/src/BaseModal.js
+++ b/src/BaseModal.js
@@ -11,41 +11,15 @@ export default {
     }
   },
 
-  data () {
-    return {
-      show: this.visible
-    }
-  },
-
   mounted () {
     this.$nextTick(() => {
       document.body.appendChild(this.$el)
     })
   },
 
-  destroyed () {
-    this.$el.remove()
-  },
-
   methods: {
-    afterLeave () {
-      this.$destroy()
-    },
-
-    active () {
-      this.show = true
-    },
-
-    deactive () {
-      this.show = false
-    },
-
     close () {
-      this.deactive()
-    },
-
-    open () {
-      this.active()
+      this.$emit('close')
     }
   },
 

--- a/src/CardModal.vue
+++ b/src/CardModal.vue
@@ -6,9 +6,8 @@
     :appear-active-class="enterClass"
     :enter-active-class="enterClass"
     :leave-active-class="leaveClass"
-    @after-leave="afterLeave"
   >
-    <div :class="['modal', 'animated', show ? 'is-active' : '']" v-if="show">
+    <div :class="['modal', 'animated', visible ? 'is-active' : '']" v-if="visible">
       <div class="modal-background" @click="close"></div>
       <div class="modal-card">
         <header class="modal-card-head">
@@ -49,12 +48,12 @@ export default {
 
   methods: {
     ok () {
-      this.close()
+      this.$emit('ok')
     },
 
     cancel () {
-      this.close()
-    }
+      this.$emit('cancel')
+    },
   }
 }
 </script>

--- a/src/ImageModal.vue
+++ b/src/ImageModal.vue
@@ -6,9 +6,8 @@
     :appear-active-class="enterClass"
     :enter-active-class="enterClass"
     :leave-active-class="leaveClass"
-    @after-leave="afterLeave"
   >
-    <div :class="['modal', 'animated', show ? 'is-active' : '']" v-if="show">
+    <div :class="['modal', 'animated', visible ? 'is-active' : '']" v-if="visible">
       <div class="modal-background" @click="close"></div>
       <div class="modal-content">
         <slot></slot>

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -6,9 +6,8 @@
     :appear-active-class="enterClass"
     :enter-active-class="enterClass"
     :leave-active-class="leaveClass"
-    @after-leave="afterLeave"
   >
-    <div :class="['modal', 'animated', show ? 'is-active' : '']" v-if="show">
+    <div :class="['modal', 'animated', visible ? 'is-active' : '']" v-if="visible">
       <div class="modal-background" @click="close"></div>
       <div class="modal-container">
         <div class="modal-content">


### PR DESCRIPTION
1、删除了组件中通过data定义的show变量，直接用props中传入的visible判断是否展示弹出。
2、删除afterLeave方法以及组件的destroyed生命周期方法，用v-if做判断可以在关闭时删除页面上的元素，觉得这里似乎没必要销毁组件。
3、为组件暴露三个绑定事件，ok(CardModel独有)，cancel(CardModel独有)，close，让用户可以自主控制弹出行为。