### PR TITLE
add opened before-close event

### DIFF
--- a/src/BaseModal.js
+++ b/src/BaseModal.js
@@ -25,7 +25,15 @@ export default {
     beforeEnter () {
       this.$emit('open')
     },
+    
+    afterEnter () {
+      this.$emit('opened')
+    },
 
+    beforeLeave () {
+      this.$emit('before-close')
+    },
+    
     afterLeave () {
       this.$emit('close')
     },

--- a/src/CardModal.vue
+++ b/src/CardModal.vue
@@ -7,6 +7,8 @@
     :enter-active-class="enterClass"
     :leave-active-class="leaveClass"
     @beforeEnter="beforeEnter"
+    @afterEnter="afterEnter"
+    @beforeLeave="beforeLeave"
     @afterLeave="afterLeave"
   >
     <div :class="classes" v-if="show">

--- a/src/ImageModal.vue
+++ b/src/ImageModal.vue
@@ -7,6 +7,8 @@
     :enter-active-class="enterClass"
     :leave-active-class="leaveClass"
     @beforeEnter="beforeEnter"
+    @afterEnter="afterEnter"
+    @beforeLeave="beforeLeave"
     @afterLeave="afterLeave"
   >
     <div :class="classes" v-if="show">

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -7,6 +7,8 @@
     :enter-active-class="enterClass"
     :leave-active-class="leaveClass"
     @beforeEnter="beforeEnter"
+    @afterEnter="afterEnter"
+    @beforeLeave="beforeLeave"
     @afterLeave="afterLeave"
   >
     <div :class="classes" v-if="show">


### PR DESCRIPTION
Sometimes we need a notification to process while the modal dialog is shown (aka set focus to some input box). So this is necessary to add a event to `opened` and `before-close` event to the component.