### PR TITLE
Fix problem with default webpack configurations. 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import Modal from './Modal'
+import Modal from './Modal.vue'
 import BaseModal from './BaseModal'
-import CardModal from './CardModal'
-import ImageModal from './ImageModal'
+import CardModal from './CardModal.vue'
+import ImageModal from './ImageModal.vue'
 
 export {
   Modal,


### PR DESCRIPTION
We need `.vue` extension specified for webpack to find the files.

Fixes https://github.com/vue-bulma/modal/issues/13