### PR TITLE
Stop using the modal-container class

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -13,10 +13,8 @@
   >
     <div :class="classes" v-if="show">
       <div class="modal-background" @click="deactive"></div>
-      <div class="modal-container">
-        <div class="modal-content">
-          <slot></slot>
-        </div>
+      <div class="modal-content">
+        <slot></slot>
       </div>
       <button class="modal-close" @click="deactive" v-if="closable"></button>
     </div>


### PR DESCRIPTION
This class breaks the horizontal centralization on small screens, and according to the Bulma [documentation](https://bulma.io/documentation/components/modal/), only the `modal` and `modal-content` classes are needed.